### PR TITLE
feat(lance): push LIMIT down into Lance scans

### DIFF
--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnector.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.transaction.IsolationLevel;
@@ -38,6 +39,7 @@ public class LanceConnector
     private final ConnectorSplitManager splitManager;
     private final ConnectorPageSourceProvider pageSourceProvider;
     private final ConnectorPageSinkProvider pageSinkProvider;
+    private final ConnectorPlanOptimizerProvider planOptimizerProvider;
 
     @Inject
     public LanceConnector(
@@ -46,7 +48,8 @@ public class LanceConnector
             LanceNamespaceHolder namespaceHolder,
             ConnectorSplitManager splitManager,
             ConnectorPageSourceProvider pageSourceProvider,
-            ConnectorPageSinkProvider pageSinkProvider)
+            ConnectorPageSinkProvider pageSinkProvider,
+            ConnectorPlanOptimizerProvider planOptimizerProvider)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -54,6 +57,7 @@ public class LanceConnector
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.planOptimizerProvider = requireNonNull(planOptimizerProvider, "planOptimizerProvider is null");
     }
 
     @Override
@@ -84,6 +88,12 @@ public class LanceConnector
     public ConnectorPageSinkProvider getPageSinkProvider()
     {
         return pageSinkProvider;
+    }
+
+    @Override
+    public ConnectorPlanOptimizerProvider getConnectorPlanOptimizerProvider()
+    {
+        return planOptimizerProvider;
     }
 
     @Override

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnectorPlanOptimizerProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnectorPlanOptimizerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public class LanceConnectorPlanOptimizerProvider
+        implements ConnectorPlanOptimizerProvider
+{
+    @Override
+    public Set<ConnectorPlanOptimizer> getLogicalPlanOptimizers()
+    {
+        return ImmutableSet.of(new LanceLimitPushdown());
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getPhysicalPlanOptimizers()
+    {
+        return ImmutableSet.of();
+    }
+}

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceFragmentPageSource.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceFragmentPageSource.java
@@ -23,6 +23,7 @@ import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 
 import java.util.List;
+import java.util.OptionalLong;
 
 public class LanceFragmentPageSource
         extends LanceBasePageSource
@@ -38,7 +39,7 @@ public class LanceFragmentPageSource
             ArrowBlockBuilder arrowBlockBuilder,
             BufferAllocator parentAllocator)
     {
-        super(tableHandle, columns, new FragmentScannerFactory(fragments, tablePath, readBatchSize), arrowBlockBuilder, parentAllocator);
+        super(tableHandle, columns, new FragmentScannerFactory(fragments, tablePath, readBatchSize, tableHandle.getLimit()), arrowBlockBuilder, parentAllocator);
     }
 
     private static class FragmentScannerFactory
@@ -47,14 +48,16 @@ public class LanceFragmentPageSource
         private final List<Integer> fragmentIds;
         private final String tablePath;
         private final int readBatchSize;
+        private final OptionalLong limit;
         private Dataset dataset;
         private LanceScanner scanner;
 
-        FragmentScannerFactory(List<Integer> fragmentIds, String tablePath, int readBatchSize)
+        FragmentScannerFactory(List<Integer> fragmentIds, String tablePath, int readBatchSize, OptionalLong limit)
         {
             this.fragmentIds = ImmutableList.copyOf(fragmentIds);
             this.tablePath = tablePath;
             this.readBatchSize = readBatchSize;
+            this.limit = limit;
         }
 
         @Override
@@ -66,6 +69,8 @@ public class LanceFragmentPageSource
             }
             optionsBuilder.batchSize(readBatchSize);
             optionsBuilder.fragmentIds(fragmentIds);
+            // Stop each scan early when a LIMIT was pushed down (best-effort; the engine still enforces exact count)
+            limit.ifPresent(optionsBuilder::limit);
 
             this.dataset = Dataset.open(tablePath, new ReadOptions.Builder().build());
             this.scanner = dataset.newScan(optionsBuilder.build());

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceLimitPushdown.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceLimitPushdown.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorPlanRewriter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.TableScanNode;
+
+import java.util.Optional;
+
+import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
+
+/**
+ * Pushes a LIMIT that sits directly above a Lance table scan into the table handle.
+ * The split manager and page source use the pushed limit to scan fewer fragments and
+ * stop each fragment scan early. The "directly above the scan" requirement keeps this
+ * correct in the presence of a filter: when a WHERE clause is present the plan is
+ * LIMIT -&gt; FILTER -&gt; SCAN, so the limit is not pushed.
+ */
+public class LanceLimitPushdown
+        implements ConnectorPlanOptimizer
+{
+    @Override
+    public PlanNode optimize(
+            PlanNode maxSubplan,
+            ConnectorSession session,
+            VariableAllocator variableAllocator,
+            PlanNodeIdAllocator idAllocator)
+    {
+        return rewriteWith(new Rewriter(), maxSubplan);
+    }
+
+    private static final class Rewriter
+            extends ConnectorPlanRewriter<Void>
+    {
+        @Override
+        public PlanNode visitLimit(LimitNode node, RewriteContext<Void> context)
+        {
+            if (!(node.getSource() instanceof TableScanNode)) {
+                return visitPlan(node, context);
+            }
+
+            TableScanNode tableScan = (TableScanNode) node.getSource();
+            TableHandle handle = tableScan.getTable();
+            if (!(handle.getConnectorHandle() instanceof LanceTableHandle)) {
+                return visitPlan(node, context);
+            }
+
+            LanceTableHandle lanceTable = (LanceTableHandle) handle.getConnectorHandle();
+            long count = node.getCount();
+            if (lanceTable.getLimit().isPresent() && lanceTable.getLimit().getAsLong() <= count) {
+                // An equal-or-tighter limit is already pushed; leave the plan unchanged
+                return node;
+            }
+
+            LanceTableHandle newLanceTable = lanceTable.withLimit(count);
+            Optional<ConnectorTableLayoutHandle> newLayout = handle.getLayout()
+                    .map(LanceTableLayoutHandle.class::cast)
+                    .map(layout -> new LanceTableLayoutHandle(newLanceTable, layout.getTupleDomain()));
+            TableHandle newHandle = new TableHandle(
+                    handle.getConnectorId(),
+                    newLanceTable,
+                    handle.getTransaction(),
+                    newLayout);
+            TableScanNode newTableScan = new TableScanNode(
+                    tableScan.getSourceLocation(),
+                    tableScan.getId(),
+                    newHandle,
+                    tableScan.getOutputVariables(),
+                    tableScan.getAssignments(),
+                    tableScan.getCurrentConstraint(),
+                    tableScan.getEnforcedConstraint(),
+                    tableScan.getCteMaterializationInfo());
+
+            // Keep the LimitNode so the engine still enforces exact LIMIT semantics; pushdown is best-effort
+            return new LimitNode(node.getSourceLocation(), node.getId(), newTableScan, count, node.getStep());
+        }
+    }
+}

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceModule.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.lance;
 import com.facebook.plugin.arrow.ArrowBlockBuilder;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -38,6 +39,7 @@ public class LanceModule
         binder.bind(ConnectorSplitManager.class).to(LanceSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSourceProvider.class).to(LancePageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(LancePageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPlanOptimizerProvider.class).to(LanceConnectorPlanOptimizerProvider.class).in(Scopes.SINGLETON);
         jsonCodecBinder(binder).bindJsonCodec(LanceCommitTaskData.class);
     }
 }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSplitManager.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSplitManager.java
@@ -56,6 +56,19 @@ public class LanceSplitManager
         List<Fragment> fragments = namespaceHolder.getFragments(
                 tableHandle.getTableName());
 
+        // With a pushed-down LIMIT, coalesce just enough leading fragments to cover it into a single
+        // split instead of one-split-per-fragment (which would scan numFragments * LIMIT rows).
+        // getNumRows() is deletion-aware and read from the already-loaded manifest, so this needs no extra IO.
+        if (tableHandle.hasLimit()) {
+            long limit = tableHandle.getLimit().getAsLong();
+            List<Integer> ids = fragments.stream().map(Fragment::getId).collect(toImmutableList());
+            List<Long> rowCounts = fragments.stream()
+                    .map(fragment -> fragment.metadata().getNumRows())
+                    .collect(toImmutableList());
+            List<Integer> coalesced = coalesceFragmentsForLimit(ids, rowCounts, limit);
+            return new FixedSplitSource(ImmutableList.of(new LanceSplit(datasetPath, coalesced)));
+        }
+
         List<ConnectorSplit> splits = fragments.stream()
                 .map(fragment -> (ConnectorSplit) new LanceSplit(
                         datasetPath,
@@ -63,5 +76,27 @@ public class LanceSplitManager
                 .collect(toImmutableList());
 
         return new FixedSplitSource(splits);
+    }
+
+    /**
+     * Returns the leading fragment IDs whose cumulative post-deletion row count covers
+     * {@code limit}. {@code rowCounts} must be deletion-aware (e.g.
+     * {@code Fragment.metadata().getNumRows()}) so fully-deleted fragments contribute 0
+     * and the walk continues past them. Always returns at least one fragment when any exist.
+     */
+    static List<Integer> coalesceFragmentsForLimit(List<Integer> fragmentIds, List<Long> rowCounts, long limit)
+    {
+        ImmutableList.Builder<Integer> selected = ImmutableList.builder();
+        long accumulated = 0;
+        int count = 0;
+        for (int i = 0; i < fragmentIds.size() && accumulated < limit; i++) {
+            selected.add(fragmentIds.get(i));
+            accumulated += rowCounts.get(i);
+            count++;
+        }
+        if (count == 0 && !fragmentIds.isEmpty()) {
+            selected.add(fragmentIds.get(0));
+        }
+        return selected.build();
     }
 }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceTableHandle.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceTableHandle.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -27,14 +28,23 @@ public class LanceTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    // Limit pushed down from a LIMIT directly above the table scan; best-effort upper bound on rows scanned
+    private final OptionalLong limit;
+
+    public LanceTableHandle(String schemaName, String tableName)
+    {
+        this(schemaName, tableName, OptionalLong.empty());
+    }
 
     @JsonCreator
     public LanceTableHandle(
             @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName)
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("limit") OptionalLong limit)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.limit = requireNonNull(limit, "limit is null");
     }
 
     @JsonProperty
@@ -49,10 +59,26 @@ public class LanceTableHandle
         return tableName;
     }
 
+    @JsonProperty
+    public OptionalLong getLimit()
+    {
+        return limit;
+    }
+
+    public boolean hasLimit()
+    {
+        return limit.isPresent();
+    }
+
+    public LanceTableHandle withLimit(long limit)
+    {
+        return new LanceTableHandle(schemaName, tableName, OptionalLong.of(limit));
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName);
+        return Objects.hash(schemaName, tableName, limit);
     }
 
     @Override
@@ -66,7 +92,8 @@ public class LanceTableHandle
         }
         LanceTableHandle other = (LanceTableHandle) obj;
         return Objects.equals(this.schemaName, other.schemaName) &&
-                Objects.equals(this.tableName, other.tableName);
+                Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.limit, other.limit);
     }
 
     @Override
@@ -75,6 +102,7 @@ public class LanceTableHandle
         return toStringHelper(this)
                 .add("schemaName", schemaName)
                 .add("tableName", tableName)
+                .add("limit", limit)
                 .toString();
     }
 }

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceLimitPushdown.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceLimitPushdown.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestLanceLimitPushdown
+{
+    private static final ConnectorId CONNECTOR_ID = new ConnectorId("lance");
+
+    @Test
+    public void testPushesLimitIntoTableScan()
+    {
+        LanceTableHandle lanceTable = new LanceTableHandle("default", "t");
+        TableScanNode scan = tableScan(lanceTable);
+        LimitNode limit = new LimitNode(Optional.empty(), new PlanNodeId("limit"), scan, 10L, LimitNode.Step.FINAL);
+
+        PlanNode result = new LanceLimitPushdown().optimize(limit, null, null, null);
+
+        assertTrue(result instanceof LimitNode);
+        TableScanNode newScan = (TableScanNode) ((LimitNode) result).getSource();
+        LanceTableHandle pushed = (LanceTableHandle) newScan.getTable().getConnectorHandle();
+        assertEquals(pushed.getLimit(), OptionalLong.of(10));
+        // the layout's wrapped table must also carry the limit (split manager reads it from the layout)
+        LanceTableLayoutHandle layout = (LanceTableLayoutHandle) newScan.getTable().getLayout().orElseThrow(AssertionError::new);
+        assertEquals(layout.getTable().getLimit(), OptionalLong.of(10));
+    }
+
+    @Test
+    public void testIdempotentWhenAlreadyPushed()
+    {
+        LanceTableHandle lanceTable = new LanceTableHandle("default", "t").withLimit(10);
+        TableScanNode scan = tableScan(lanceTable);
+        LimitNode limit = new LimitNode(Optional.empty(), new PlanNodeId("limit"), scan, 10L, LimitNode.Step.FINAL);
+
+        PlanNode result = new LanceLimitPushdown().optimize(limit, null, null, null);
+
+        // nothing tighter to push, returned unchanged
+        assertSame(result, limit);
+    }
+
+    private static TableScanNode tableScan(LanceTableHandle lanceTable)
+    {
+        TableHandle tableHandle = new TableHandle(
+                CONNECTOR_ID,
+                lanceTable,
+                LanceTransactionHandle.INSTANCE,
+                Optional.of(new LanceTableLayoutHandle(lanceTable, TupleDomain.all())));
+        return new TableScanNode(
+                Optional.empty(),
+                new PlanNodeId("scan"),
+                tableHandle,
+                ImmutableList.of(),
+                ImmutableMap.<com.facebook.presto.spi.relation.VariableReferenceExpression, ColumnHandle>of(),
+                TupleDomain.all(),
+                TupleDomain.all(),
+                Optional.empty());
+    }
+}

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSplitManager.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSplitManager.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestLanceSplitManager
+{
+    private LanceNamespaceHolder namespaceHolder;
+    private LanceSplitManager splitManager;
+    private LanceTableHandle tableHandle;
+    private int fragmentCount;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        URL dbUrl = Resources.getResource(TestLanceSplitManager.class, "/example_db");
+        String rootPath = Paths.get(dbUrl.toURI()).toString();
+        LanceConfig config = new LanceConfig()
+                .setRootUrl(rootPath)
+                .setSingleLevelNs(true);
+        namespaceHolder = new LanceNamespaceHolder(config);
+        splitManager = new LanceSplitManager(namespaceHolder);
+        tableHandle = new LanceTableHandle("default", "test_table1");
+        fragmentCount = namespaceHolder.getFragments("test_table1").size();
+    }
+
+    @Test
+    public void testGetSplitsWithoutLimitProducesSplitPerFragment()
+    {
+        List<ConnectorSplit> splits = drain(splitManager.getSplits(
+                null, null, new LanceTableLayoutHandle(tableHandle, TupleDomain.all()), null));
+        assertEquals(splits.size(), fragmentCount);
+    }
+
+    @Test
+    public void testGetSplitsWithLimitProducesSingleCoalescedSplit()
+    {
+        List<ConnectorSplit> splits = drain(splitManager.getSplits(
+                null, null, new LanceTableLayoutHandle(tableHandle.withLimit(1), TupleDomain.all()), null));
+        assertEquals(splits.size(), 1);
+        // the coalesced split covers the limit using at least one fragment
+        assertTrue(((LanceSplit) splits.get(0)).getFragments().size() >= 1);
+    }
+
+    @Test
+    public void testCoalesceStopsAtFirstFragmentCoveringLimit()
+    {
+        List<Integer> selected = LanceSplitManager.coalesceFragmentsForLimit(
+                ImmutableList.of(0, 1, 2), ImmutableList.of(100L, 100L, 100L), 50);
+        assertEquals(selected, ImmutableList.of(0));
+    }
+
+    @Test
+    public void testCoalesceSpansMultipleFragments()
+    {
+        List<Integer> selected = LanceSplitManager.coalesceFragmentsForLimit(
+                ImmutableList.of(0, 1, 2), ImmutableList.of(100L, 100L, 100L), 150);
+        assertEquals(selected, ImmutableList.of(0, 1));
+    }
+
+    @Test
+    public void testCoalesceLimitExceedsTotalReturnsAll()
+    {
+        List<Integer> selected = LanceSplitManager.coalesceFragmentsForLimit(
+                ImmutableList.of(0, 1, 2), ImmutableList.of(100L, 100L, 100L), 1000);
+        assertEquals(selected, ImmutableList.of(0, 1, 2));
+    }
+
+    @Test
+    public void testCoalesceWalksPastDeletedFragments()
+    {
+        // Fully-deleted fragments contribute 0 rows; the walk continues until the limit is covered
+        List<Integer> selected = LanceSplitManager.coalesceFragmentsForLimit(
+                ImmutableList.of(0, 1, 2), ImmutableList.of(0L, 0L, 5L), 3);
+        assertEquals(selected, ImmutableList.of(0, 1, 2));
+    }
+
+    @Test
+    public void testCoalesceAlwaysReturnsAtLeastOneFragment()
+    {
+        List<Integer> selected = LanceSplitManager.coalesceFragmentsForLimit(
+                ImmutableList.of(7), ImmutableList.of(0L), 10);
+        assertEquals(selected, ImmutableList.of(7));
+    }
+
+    @Test
+    public void testCoalesceEmptyFragments()
+    {
+        List<Integer> selected = LanceSplitManager.coalesceFragmentsForLimit(
+                ImmutableList.of(), ImmutableList.of(), 10);
+        assertEquals(selected, ImmutableList.of());
+    }
+
+    private static List<ConnectorSplit> drain(ConnectorSplitSource source)
+    {
+        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
+        try {
+            while (!source.isFinished()) {
+                splits.addAll(source.getNextBatch(NOT_PARTITIONED, 1000).get().getSplits());
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return splits.build();
+    }
+}

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceTableHandle.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceTableHandle.java
@@ -16,8 +16,12 @@ package com.facebook.presto.lance;
 import com.facebook.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
 
+import java.util.OptionalLong;
+
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestLanceTableHandle
 {
@@ -30,5 +34,35 @@ public class TestLanceTableHandle
         String json = codec.toJson(tableHandle);
         LanceTableHandle copy = codec.fromJson(json);
         assertEquals(copy, tableHandle);
+    }
+
+    @Test
+    public void testDefaultHasNoLimit()
+    {
+        assertEquals(tableHandle.getLimit(), OptionalLong.empty());
+        assertFalse(tableHandle.hasLimit());
+    }
+
+    @Test
+    public void testWithLimit()
+    {
+        LanceTableHandle withLimit = tableHandle.withLimit(10);
+        assertTrue(withLimit.hasLimit());
+        assertEquals(withLimit.getLimit(), OptionalLong.of(10));
+        // original is unchanged (immutable)
+        assertFalse(tableHandle.hasLimit());
+        // schema/table preserved
+        assertEquals(withLimit.getSchemaName(), "default");
+        assertEquals(withLimit.getTableName(), "test_table");
+    }
+
+    @Test
+    public void testJsonRoundTripWithLimit()
+    {
+        JsonCodec<LanceTableHandle> codec = jsonCodec(LanceTableHandle.class);
+        LanceTableHandle withLimit = tableHandle.withLimit(25);
+        LanceTableHandle copy = codec.fromJson(codec.toJson(withLimit));
+        assertEquals(copy, withLimit);
+        assertEquals(copy.getLimit(), OptionalLong.of(25));
     }
 }


### PR DESCRIPTION
## Summary
Adds LIMIT pushdown to the Presto Lance connector. PrestoDB has no `applyLimit` SPI, so this uses a `ConnectorPlanOptimizer`.

- **Plan optimizer**: `LanceLimitPushdown` rewrites a `LimitNode` sitting directly over a Lance `TableScanNode` into a `LanceTableHandle` carrying the row count (wired via `LanceConnectorPlanOptimizerProvider` → `LanceModule` → `LanceConnector.getConnectorPlanOptimizerProvider`). Only fires when LIMIT is directly over the scan (no intervening FILTER), so semantics stay exact.
- **Split coalescing**: with a pushed-down limit, the split manager coalesces just enough leading fragments to cover it into a single split (deletion-aware via `Fragment.metadata().getNumRows()`) instead of one-split-per-fragment.
- **Scan limit**: the fragment page source passes `ScanOptions.limit(n)` to stop each scan early.

Best-effort IO reduction — the engine still enforces the exact row count.

## Test plan
- New unit tests: `TestLanceLimitPushdown` (pushes into scan, idempotent), `TestLanceSplitManager` (split-per-fragment vs single coalesced split + coalesce helper edge cases), additions to `TestLanceTableHandle` (limit field + JSON round-trip).
- `./mvnw -o test -pl presto-lance` → **37 tests, BUILD SUCCESS**.

> Stacked on #4 — review/merge that first. The diff here is just the LIMIT-pushdown changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)